### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/devbox-base.yml
+++ b/.github/workflows/devbox-base.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: oysteinlunde/devbox/devbox
         dockerfile: Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore